### PR TITLE
Add function type mismatch

### DIFF
--- a/mubsan.c
+++ b/mubsan.c
@@ -66,9 +66,18 @@ typedef struct {
     mubsan_type_description* lhs_type;
     mubsan_type_description* rhs_type;
 } mubsan_shift_out_of_bounds;
+
 typedef struct {
     mubsan_source_location loc;
 } mubsan_unreachable;
+
+typedef struct {
+    mubsan_source_location loc;
+    mubsan_type_description* expected_type;
+    mubsan_type_description* actual_type;
+    void *function;
+} mubsan_function_type_mismatch;
+
 void __ubsan_handle_type_mismatch_v1(mubsan_type_mismatch_info_v1* data, uintptr_t ptr) {
     const char* reason = "type mismatch";
 
@@ -178,4 +187,13 @@ void __ubsan_handle_builtin_unreachable(mubsan_unreachable* data) {
                data->loc.file,
                data->loc.line,
                data->loc.col);
+}
+void __ubsan_handle_function_type_mismatch(mubsan_function_type_mismatch* data) {
+    mubsan_log("mubsan @ %s:%d:%d: function type mismatch, expected %s but got %s at address %lx\n",
+               data->loc.file,
+               data->loc.line,
+               data->loc.col,
+               data->expected_type->name,
+               data->actual_type->name,
+               data->function);
 }


### PR DESCRIPTION
GCC doesn't complain if I don't have this, but clang does, so that's why I added it